### PR TITLE
Fix DB queries for SSH Fingerprint

### DIFF
--- a/datastore/postgres/url.go
+++ b/datastore/postgres/url.go
@@ -58,6 +58,7 @@ func (u *urlRepositoryTable) Latest(ctx context.Context, userID uuid.UUID) (
 
 	err := bun.NewSelectQuery(u.inner).Model(ret).
 		Order("created_at DESC").
+		Where("user_id = ?", userID).
 		Limit(1).
 		Scan(ctx)
 

--- a/datastore/postgres/user.go
+++ b/datastore/postgres/user.go
@@ -32,9 +32,10 @@ func (u *userRepositoryTable) Find(ctx context.Context,
 ) (*sdump.User, error) {
 	res := new(sdump.User)
 
-	query := bun.NewSelectQuery(u.inner).Model(res)
+	err := bun.NewSelectQuery(u.inner).Model(res).
+		Where("ssh_finger_print = ?", opts.SSHKeyFingerprint).
+		Scan(ctx)
 
-	err := query.Scan(ctx, res)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, sdump.ErrUserNotFound
 	}


### PR DESCRIPTION
In #24 , we introduced persisting urls using the ssh fingerprint of the key used to connect to the ssh server
but for some weird reason while cherry-picking commits from another branch into the pr for #24 , I seem to have 
messed it up. 

