### PR TITLE
Limit access to ssh server by public keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .ssh/
 # deploy/
+id_ed25*

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -103,13 +103,12 @@ func validateSSHPublicKey(cfg *config.Config) ssh.Option {
 			return true
 		}
 
-		for _, v := range sshKeys {
-			if ssh.KeysEqual(v, key) {
-				return true
-			}
+		publicKey, ok := sshKeys[gossh.FingerprintSHA256(key)]
+		if !ok {
+			return false
 		}
 
-		return false
+		return ssh.KeysEqual(publicKey, key)
 	})
 }
 

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -81,16 +81,16 @@ func createSSHCommand(rootCmd *cobra.Command, cfg *config.Config) {
 }
 
 func validateSSHPublicKey(cfg *config.Config) ssh.Option {
-	sshKeys := make(map[string]gossh.PublicKey, len(cfg.SSH.Allowlist))
+	sshKeys := make(map[string]gossh.PublicKey, len(cfg.SSH.AllowList))
 
-	for _, v := range cfg.SSH.Allowlist {
+	for _, v := range cfg.SSH.AllowList {
 
 		pemBytes, err := os.ReadFile(v)
 		if err != nil {
 			log.Fatalf("could not fetch ssh key ( %s ).. %v", v, err)
 		}
 
-		publicKey, err := gossh.ParsePublicKey(pemBytes)
+		publicKey, _, _, _, err := gossh.ParseAuthorizedKey(pemBytes)
 		if err != nil {
 			log.Fatalf("could not parse ssh key ( %s ).. %v", v, err)
 		}
@@ -128,7 +128,7 @@ func teaHandler(cfg *config.Config) func(s ssh.Session) (tea.Model, []tea.Progra
 			tui.WithSSHFingerPrint(sshFingerPrint),
 		)
 		if err != nil {
-			wish.Fatalln(s, fmt.Errorf("%v...Could not set up TUI session..", err))
+			wish.Fatalln(s, fmt.Errorf("%v...Could not set up TUI session", err))
 			return nil, nil
 		}
 

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -28,16 +28,13 @@ func createSSHCommand(rootCmd *cobra.Command, cfg *config.Config) {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			s, err := wish.NewServer(
 				wish.WithAddress(fmt.Sprintf("%s:%d", cfg.SSH.Host, cfg.SSH.Port)),
+				wish.WithPublicKeyAuth(func(_ ssh.Context, pubKey ssh.PublicKey) bool {
+					return true
+				}),
 				wish.WithMiddleware(
 					bm.Middleware(teaHandler(cfg)),
 					lm.Middleware(),
 				),
-				wish.WithPublicKeyAuth(func(_ ssh.Context, pubKey ssh.PublicKey) bool {
-					// allow all public keys go true
-					// TODO: implement public key authentication
-
-					return true
-				}),
 			)
 			if err != nil {
 				return err
@@ -94,6 +91,7 @@ func teaHandler(cfg *config.Config) func(s ssh.Session) (tea.Model, []tea.Progra
 		}
 
 		sshFingerPrint := gossh.FingerprintSHA256(s.PublicKey())
+		fmt.Println(sshFingerPrint)
 
 		tuiModel, err := tui.New(cfg,
 			tui.WithWidth(pty.Window.Width),

--- a/config.yml
+++ b/config.yml
@@ -5,6 +5,9 @@ cron:
 
 ssh:
   port: 2222
+  allow_list:
+    - ~/.ssh/Lanre.pem
+    - ~/.ssh/id_rsa.pub
   identities:
     - "id_ed25519"
 

--- a/config.yml
+++ b/config.yml
@@ -6,8 +6,8 @@ cron:
 ssh:
   port: 2222
   allow_list:
-    - ~/.ssh/Lanre.pem
-    - ~/.ssh/id_rsa.pub
+    - ./.ssh/id_rsa.pub
+    - /Users/lanreadelowo/.ssh/id_rsa.pub
   identities:
     - "id_ed25519"
 

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,10 @@ type SSHConfig struct {
 	// Identities is an array containing private keys for the ssh server
 	// By default it uses .ssh/id_rsa only
 	Identities []string `mapstructure:"identities" json:"identities,omitempty" yaml:"identities"`
+
+	// Allowlist is a list of paths to public keys that should be accepted when connecting to the sshssh/i
+	// server
+	Allowlist []string `mapstructure:"allowlist" json:"allowlist,omitempty" yaml:"allowlist"`
 }
 
 type HTTPConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -14,9 +14,9 @@ type SSHConfig struct {
 	// By default it uses .ssh/id_rsa only
 	Identities []string `mapstructure:"identities" json:"identities,omitempty" yaml:"identities"`
 
-	// Allowlist is a list of paths to public keys that should be accepted when connecting to the sshssh/i
+	// AllowList is a list of paths to public keys that should be accepted when connecting to the sshssh/i
 	// server
-	Allowlist []string `mapstructure:"allowlist" json:"allowlist,omitempty" yaml:"allowlist"`
+	AllowList []string `json:"allow_list,omitempty" mapstructure:"allow_list" yaml:"allow_list"`
 }
 
 type HTTPConfig struct {


### PR DESCRIPTION
Fixes #27 . This would allow people run instances where only authorised users can use the ssh server.

If you leave the `ssh.allow_list` empty, all ssh connections will be accepted

![CleanShot 2024-02-10 at 01 11 08](https://github.com/adelowo/sdump/assets/12677701/d5d4bbea-b254-4032-8caa-092e5087226f)


